### PR TITLE
Switch from 256 to 512 tiles, and from topojson to MVT

### DIFF
--- a/scene.yaml
+++ b/scene.yaml
@@ -1,14 +1,16 @@
 sources:
     elevation:
         type: Raster
-        url: https://tile.nextzen.org/tilezen/terrain/v1/256/terrarium/{z}/{x}/{y}.png
+        url: https://tile.nextzen.org/tilezen/terrain/v1/512/terrarium/{z}/{x}/{y}.png
         max_zoom: 14
+        tile_size: 512
         url_params:
             api_key: dmlO1fVQRPKI-GrVIYJ1YA
     mapzen:
-        type: TopoJSON
-        url: https://tile.nextzen.org/tilezen/vector/v1/256/all/{z}/{x}/{y}.topojson
+        type: MVT
+        url: https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt
         max_zoom: 16
+        tile_size: 512
         url_params:
             api_key: dmlO1fVQRPKI-GrVIYJ1YA
 styles:


### PR DESCRIPTION
The Heightmapper code is currently the primary user of Nextzen tiles. Additionally, almost no one else requests TopoJSON tiles.

To reduce the caching universe, this PR switches from "256 pixel" to "512 pixel" vector and raster tiles and switches from TopoJSON to MVT.